### PR TITLE
LOAD_PATH with symlinks

### DIFF
--- a/whatweb
+++ b/whatweb
@@ -96,11 +96,19 @@ else
         require 'md5'
 end
 
+
 # add the directory of the file currently being executed to the load path
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__))) unless
     $:.include?(File.dirname(__FILE__)) || $LOAD_PATH.include?(File.expand_path(File.dirname(__FILE__)))
 $LOAD_PATH << "/usr/share/whatweb/"
 
+# if __FILE__ is a symlink then follow *every* symlink
+if File.symlink?(__FILE__)
+  require 'pathname'
+  $LOAD_PATH << File.dirname( Pathname.new(__FILE__).realpath )
+end
+
+require 'lib/plugins.rb'
 require 'lib/plugins.rb'
 require 'lib/output.rb'
 require 'lib/colour.rb'


### PR DESCRIPTION
This fixes the LOAD_PATH if the "whatweb" executable is a symlink (and following files might be symlinks as well)

I made this because the LOAD_PATH with **FILE** fails with Brew package management.
