### PR TITLE
add signatures for wordpress up to version 3.8

### DIFF
--- a/plugins/wordpress.rb
+++ b/plugins/wordpress.rb
@@ -790,11 +790,11 @@ matches [
                     ],
                       "3.8" =>
                     [["readme.html", "38ee273095b8f25b9ffd5ce5018fc4f0"],
-                      ["wp-admin/css/wp-admin.css", "68600417d5dc22244168b4eeb84f0af4"]
+                      ["wp-admin/css/wp-admin.css", "25554fc81989c307119b7d4818dc3963"]
                     ],
                       "3.8.1" =>
                     [["readme.html", "0d0eb101038124a108f608d419387b92"],
-                      ["wp-admin/css/wp-admin.css", "25554fc81989c307119b7d4818dc3963"]]
+                      ["wp-admin/css/wp-admin.css", "68600417d5dc22244168b4eeb84f0af4"]]
     ]
     
     v = Version.new("Joomla", versions, @base_uri)


### PR DESCRIPTION
Hi there! 

How's it going?

Added fingerprints for wordpress, below are the results of some tests:

```
http://opportunity/wordpress-3.4.2.tar.gz_extracted/wordpress/ [500] WordPress[3.4.1,3.4.2]
http://opportunity/wordpress-3.5.1.tar.gz_extracted/wordpress/ [500] WordPress[3.5.1,3.5.2]
http://opportunity/wordpress-3.5.2.tar.gz_extracted/wordpress/ [500] WordPress[3.5.1,3.5.2]
http://opportunity/wordpress-3.5.tar.gz_extracted/wordpress/ [200] WordPress[3.5]          
http://opportunity/wordpress-3.6.1.tar.gz_extracted/wordpress/ [500] WordPress[3.6,3.6.1]  
http://opportunity/wordpress-3.6.tar.gz_extracted/wordpress/ [500] WordPress[3.6,3.6.1]    
http://opportunity/wordpress-3.7.1.tar.gz_extracted/wordpress/ [500] WordPress[3.7,3.7.1]  
http://opportunity/wordpress-3.7.tar.gz_extracted/wordpress/ [500] WordPress[3.7,3.7.1]    
http://opportunity/wordpress-3.8.1.tar.gz_extracted/wordpress/ [500] WordPress[3.8.1]      
http://opportunity/wordpress-3.8.tar.gz_extracted/wordpress/ [500] WordPress[3.8]          
```
