### PR TITLE
Fixed bug on OS X 10.9 (Ruby 2.0)

### DIFF
--- a/lib/extend-http.rb
+++ b/lib/extend-http.rb
@@ -97,7 +97,7 @@ class ExtendedHTTP < Net::HTTP   #:nodoc:
 	end
 
 
-        if RUBY_VERSION =~ /^1\.9/
+        if RUBY_VERSION =~ /^1\.9/ || RUBY_VERSION =~ /^2\.0/
 	      D "opening connection to #{conn_address()}..."
 	      s = timeout(@open_timeout) { TCPSocket.open(conn_address(), conn_port()) }
 	      D "opened"


### PR DESCRIPTION
I believe this addresses issue #116. Just tested a couple of sites and worked fine with ruby 2.0.0p353
