### PR TITLE
Add new versions of wordpress

### DIFF
--- a/plugins/wordpress.rb
+++ b/plugins/wordpress.rb
@@ -812,19 +812,6 @@ matches [
                     [["readme.html", "84b54c54aa48ae72e633685c17e67457"],
                       ["wp-admin/css/wp-admin.css", "ff37a40c48d23ba4ecc09d9a98da1247"]
 		    ],
-
-
-#0d0eb101038124a108f608d419387b92  /var/www/wordpress-3.8.1/readme.html
-#  /var/www/wordpress-3.8.2/readme.html
-#  /var/www/wordpress-3.8.3/readme.html
-#kkkkkkkkkkkkk  /var/www/wordpress-3.9.1/readme.html
-#  /var/www/wordpress-3.9/readme.html
-
-#68600417d5dc22244168b4eeb84f0af4  /var/www/wordpress-3.8.1/wp-admin/css/wp-admin.css
-#68600417d5dc22244168b4eeb84f0af4  /var/www/wordpress-3.8.2/wp-admin/css/wp-admin.css
-#68600417d5dc22244168b4eeb84f0af4  /var/www/wordpress-3.8.3/wp-admin/css/wp-admin.css
-#ff37a40c48d23ba4ecc09d9a98da1247  /var/www/wordpress-3.9.1/wp-admin/css/wp-admin.css
-#ff37a40c48d23ba4ecc09d9a98da1247  /var/www/wordpress-3.9/wp-admin/css/wp-admin.css
     ]
     
     v = Version.new("WordPress", versions, @base_uri)


### PR DESCRIPTION
Hi There!

Just creating this pull request to add the newly released versions of wordpress

<pre>
root@opportinity:~/WhatWeb# for version in `printf "%s\n" 3.8.1 3.8.2 3.8.3 3.9 3.9.1`;do ./whatweb -a 4 -p plugins/wordpress.rb http://localhost/wordpress-$version/; done
http://localhost/wordpress-3.8.1/ [500] WordPress[3.8.1]
http://localhost/wordpress-3.8.2/ [500] WordPress[3.8.2]
http://localhost/wordpress-3.8.3/ [500] WordPress[3.8.3]
http://localhost/wordpress-3.9/ [500] WordPress[3.9.1]
http://localhost/wordpress-3.9.1/ [500] WordPress[3.9]
</pre>
