### PR TITLE
add initial cgit plugin

### DIFF
--- a/plugins/cgit.rb
+++ b/plugins/cgit.rb
@@ -1,0 +1,46 @@
+##
+# This file is part of WhatWeb and may be subject to
+# redistribution and commercial restrictions. Please see the WhatWeb
+# web site for more information on licensing and terms of use.
+# http://www.morningstarsecurity.com/research/whatweb
+##
+# Version 0.1 # 2014-07-20 #
+# Initial version
+##
+Plugin.define "cgit" do
+author "Fabian Affolter <fabian@engineering.ch>" # 2014-07-20
+version "0.1"
+description "A web frontend for git repositories written in C. - Homepage: http://git.zx2c4.com/cgit/"
+
+# Matches #
+matches [
+# ID
+{ :text=>"<div id='cgit'><table id='header'>" },
+
+# Default CSS
+{ :text=>"<link rel='stylesheet' type='text/css' href='/cgit.css'/>" },
+
+# Footer
+{ :text=>"<div class='footer'>Copyright &copy; 2000 &ndash; 20[\d]{2} Jason A. Donenfeld. All Rights Reserved.</div>" },
+
+# Generator
+{ :name=>'meta generator',
+:text=>"<meta name='generator' content='cgit v([^\s]+)'\/>"
+},
+
+]
+
+# Passive #
+def passive
+	m=[]
+    # Version detection
+	if @body =~ /<meta name='generator' content='cgit v([^\s]+)'\/>/
+		version = @body.scan(/<meta name='generator' content='cgit v([^\s]+)'\/>/)[0][0]
+		m << { :version=>version }
+	end
+	m
+
+end
+
+end
+


### PR DESCRIPTION
This pull request contains a simple plugin for the detection of cgit.

```
$ ./whatweb git.kernel.org
http://git.kernel.org [301] HTTPServer[nginx], IP[149.20.4.72], RedirectLocation[https://git.kernel.org/cgit/], Title[301 Moved Permanently], nginx
https://git.kernel.org/cgit/ [200] HTTPServer[nginx], IP[199.204.44.194], Title[Kernel.org git repositories], cgit[0.10.1], nginx
```
