### PR TITLE
Allow Ruby versions higher than 2.0.x

### DIFF
--- a/lib/extend-http.rb
+++ b/lib/extend-http.rb
@@ -97,7 +97,7 @@ class ExtendedHTTP < Net::HTTP   #:nodoc:
 	end
 
 
-        if RUBY_VERSION =~ /^1\.9/ || RUBY_VERSION =~ /^2\.0/
+        if RUBY_VERSION =~ /^1\.9/ || RUBY_VERSION =~ /^2\./
 	      D "opening connection to #{conn_address()}..."
 	      s = timeout(@open_timeout) { TCPSocket.open(conn_address(), conn_port()) }
 	      D "opened"

--- a/whatweb
+++ b/whatweb
@@ -49,7 +49,7 @@ require 'resolv-replace' # asynchronous DNS
 
 
 ### ruby 1.9 changes
-if RUBY_VERSION =~ /^1\.9/ || RUBY_VERSION =~ /^2\.0/
+if RUBY_VERSION =~ /^1\.9/ || RUBY_VERSION =~ /^2\./
         require 'digest/md5'
 else
         require 'md5'


### PR DESCRIPTION
Replace regex' checking for 2.0 with checks for 2. preventing
Ruby 1.8 behavior in 2.1 and up.
