### PR TITLE
Fixed 'undefined method join for String' bug

### DIFF
--- a/lib/target.rb
+++ b/lib/target.rb
@@ -173,7 +173,7 @@ class Target
 				req.basic_auth $BASIC_AUTH_USER, $BASIC_AUTH_PASS
 			end
 			res=http.request(req)
-			@raw_headers=http.raw.join("\n")
+			@raw_headers="#{http.raw}\n"
 			@headers={}; res.each_header {|x,y| @headers[x]=y }
 			@headers["set-cookie"] = res.get_fields('set-cookie').join("\n") unless @headers["set-cookie"].nil?
 			@body=res.body


### PR DESCRIPTION
Fixed 'undefined method join for String' bug, `String` object do not have a join method.

Testing environment:
* OS: ubuntu
* OS release: 14.04
* Ruby version: ruby 1.8.7 (2014-01-28 patchlevel 376) [x86_64-linux]

How to reproduce the bug:
```bash
git clone https://github.com/urbanadventurer/WhatWeb
cd WhatWeb
make install
whatweb "https://example.com"
```