### PR TITLE
Add unit tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,32 @@
+##
+# This file is part of WhatWeb and may be subject to
+# redistribution and commercial restrictions. Please see the WhatWeb
+# web site for more information on licensing and terms of use.
+# http://www.morningstarsecurity.com/research/whatweb
+##
+source 'https://rubygems.org'
+
+# JSON logging - optional
+group :json do
+  #gem 'json'
+end
+
+# MongoDB logging - optional
+group :mongo do
+  #gem 'mongo'
+  #gem 'rchardet'
+end
+
+# Character set detection - optional
+group :rchardet do
+  #gem 'rchardet'
+end
+
+# Development dependencies required for tests
+group :test do
+  gem 'rake'
+  gem 'minitest'
+  gem 'rubocop'
+  gem 'rdoc'
+  gem 'bundler-audit'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,72 @@
+##
+# This file is part of WhatWeb and may be subject to
+# redistribution and commercial restrictions. Please see the WhatWeb
+# web site for more information on licensing and terms of use.
+# http://www.morningstarsecurity.com/research/whatweb
+##
+$DEBUG = false
+$VERBOSE = false
+require 'rake/testtask'
+require 'rubocop/rake_task'
+
+desc 'Run all tests'
+task :all do
+  puts 'Running unit tests'
+  Rake::Task['unit'].invoke
+end
+
+task :default => :unit
+
+Rake::TestTask.new(:unit) do |t|
+  t.description = 'Run unit tests'
+  t.test_files = FileList['test/unit.rb']
+end
+
+desc 'Run bundle-audit'
+task :bundle_audit do
+  Rake::Task['bundle_audit:update'].invoke
+  Rake::Task['bundle_audit:check'].invoke
+end
+
+desc 'Generate API documentation to doc/rdocs/index.html'
+task :rdoc do
+  Rake::Task['rdoc:rerdoc'].invoke
+end
+
+RuboCop::RakeTask.new
+
+############################################################
+# rdoc
+############################################################
+namespace :rdoc do
+  require 'rdoc/task'
+
+  desc 'Generate API documentation to doc/rdocs/index.html'
+  Rake::RDocTask.new do |rd|
+    rd.rdoc_dir = 'doc/rdocs'
+    rd.main = 'README'
+    rd.rdoc_files.include(
+      'whatweb',
+      'lib/*\.rb')
+    rd.options << '--line-numbers'
+    rd.options << '--all'
+  end
+end
+
+############################################################
+# bundle-audit
+############################################################
+namespace :bundle_audit do
+  require 'bundler/audit/cli'
+
+  desc 'Update bundle-audit database'
+  task :update do
+    Bundler::Audit::CLI.new.update
+  end
+
+  desc 'Check gems for vulns using bundle-audit'
+  task :check do
+    Bundler::Audit::CLI.new.check
+  end
+end
+

--- a/test/unit.rb
+++ b/test/unit.rb
@@ -1,0 +1,127 @@
+##
+# This file is part of WhatWeb and may be subject to
+# redistribution and commercial restrictions. Please see the WhatWeb
+# web site for more information on licensing and terms of use.
+# http://www.morningstarsecurity.com/research/whatweb
+##
+require 'minitest/autorun'
+
+class WhatWebTest < Minitest::Test
+
+  def setup
+    @test_host = 'whatweb.net'
+  end
+
+  def test_version
+    p = IO.popen(['./whatweb', '--version'], 'r+')
+    res = p.read.to_s
+    p.close
+    assert res
+    assert res =~ %r{^WhatWeb version \d.\d.\d-dev \( http://www.morningstarsecurity.com/research/whatweb/ \)$}
+  end
+
+  def test_invalid_url
+    p = IO.popen(['./whatweb',
+      '--color', 'never',
+      '--no-errors',
+      'http://'], 'r+')
+    res = p.read.to_s
+    p.close
+    assert res
+    assert_equal '', res
+  end
+
+  def test_xml_output
+    p = IO.popen(['./whatweb',
+      '--color', 'never',
+      '--log-xml', '/dev/stdout',
+      "http://#{@test_host}/"], 'r+')
+    res = p.read.to_s
+    p.close
+    assert res
+    assert res =~ %r{<http-status>200</http-status>}
+  end
+
+  def test_json_output
+    p = IO.popen(['./whatweb',
+      '--color', 'never',
+      '--log-json', '/dev/stdout',
+      "http://#{@test_host}/"], 'r+')
+    res = p.read.to_s
+    p.close
+    assert res
+    assert res =~ %r{"http_status":200}
+  end
+
+  def test_object_output
+    p = IO.popen(['./whatweb',
+      '--color', 'never',
+      '--log-object', '/dev/stdout',
+      "http://#{@test_host}/"], 'r+')
+    res = p.read.to_s
+    p.close
+    assert res
+    assert res =~ %r{Identifying: http://#{@test_host}/}
+    assert res =~ %r{^HTTP-Status: 200$}
+    assert res =~ %r{:name=>"server string", :string=>"Apache", :certainty=>100}
+  end
+
+  def test_sql_output
+    p = IO.popen(['./whatweb',
+      '--color', 'never',
+      '--log-sql', '/dev/stdout',
+      "http://#{@test_host}/"], 'r+')
+    res = p.read.to_s
+    p.close
+    assert res
+    assert res.split("\n").flatten.first =~ %r{^INSERT IGNORE INTO targets \(status,target\) VALUES \('200','http://#{@test_host}/'\);$}
+  end
+
+  def test_verbose_output
+    p = IO.popen(['./whatweb',
+      '--color', 'never',
+      '--verbose',
+      "http://#{@test_host}/"], 'r+')
+    res = p.read.to_s
+    p.close
+    assert res
+    assert res.split("\n").flatten.first =~ %r{WhatWeb report for http://#{@test_host}/$}
+  end
+
+  def test_plugins
+    p = IO.popen(['./whatweb',
+      '--color', 'never',
+      '-phttpserver,title',
+      "http://#{@test_host}/"], 'r+')
+    res = p.read.to_s
+    p.close
+    assert res
+    assert res =~ %r{^http://#{@test_host}/ \[200 OK\] HTTPServer\[Apache\], Title\[WhatWeb - Next generation web scanner.\]$}
+  end
+
+  def test_custom_plugin
+    p = IO.popen(['./whatweb',
+      '--color', 'never',
+      '--custom-plugin', ':text=>"WhatWeb - Next generation web scanner."',
+      "http://#{@test_host}/"], 'r+')
+    res = p.read.to_s
+    p.close
+    assert res
+    assert res =~ %r{Custom-Plugin}
+  end
+
+  def test_invalid_custom_plugin
+    junk = "#{('a'..'z').to_a.shuffle[0,8].join}"
+    p = IO.popen(['./whatweb',
+      '--color', 'never',
+      '--no-errors',
+      '--custom-plugin', ":text=>#{junk}",
+      "http://#{@test_host}/"], 'r+')
+    res = p.read.to_s
+    p.close
+    assert res
+    assert_equal '', res
+  end
+
+end
+


### PR DESCRIPTION
Add simple unit tests.

``` bash
$ rake
Run options: --seed 10623

# Running:

....Invalid custom plugin syntax: :text=>vmdbuhaz
./pentest/web/whatweb/lib/target.rb:189: warning: constant Target::TimeoutError is deprecated
.....

Finished in 9.598764s, 1.0418 runs/s, 2.2920 assertions/s.

10 runs, 22 assertions, 0 failures, 0 errors, 0 skips
```

``` bash
$ rake -T
rake all                   # Run all tests
rake bundle_audit          # Run bundle-audit
rake bundle_audit:check    # Check gems for vulns using bundle-audit
rake bundle_audit:update   # Update bundle-audit database
rake rdoc                  # Generate API documentation to doc/rdocs/index.html
rake rdoc:clobber_rdoc     # Remove RDoc HTML files
rake rdoc:rdoc             # Build RDoc HTML files
rake rdoc:rerdoc           # Rebuild RDoc HTML files
rake rubocop               # Run RuboCop
rake rubocop:auto_correct  # Auto-correct RuboCop offenses
rake unit                  # Run unit tests
```
