### PR TITLE
Ignore DS_Store and Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .project
+.DS_Store
+Gemfile.lock


### PR DESCRIPTION
Can we please ignore these? 
DS_Store is created by OSX, and Gemfile.lock appears on bundle install.