### PR TITLE
Remove Ruby 1.9 - Ruby 1.x is EOL and no longer supported from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9
   - 2.0
   - 2.1
   - 2.2


### PR DESCRIPTION
It seems that Ruby 1.9 builds are not supported anymore, so it would help me to remove them from travis :)