### PR TITLE
Bugfix in TYPO3 Plugin Version Detection

### DIFF
--- a/plugins/jquery.rb
+++ b/plugins/jquery.rb
@@ -29,6 +29,7 @@ matches [
 
 # JavaScript # Version Detection
 { :version=>/jquery(\.min)?\.js\?ver=([0-9\.]+)['"]/, :offset=>1 },
+{ :version=>/jquery\/([0-9\.]+)\/jquery(\.min)?\.js/, :offset=>0 },
 { :version=>/jquery-([0-9\.]+)(\.min)?\.js/, :offset=>0 }
 
 ]

--- a/plugins/jquery.rb
+++ b/plugins/jquery.rb
@@ -29,7 +29,6 @@ matches [
 
 # JavaScript # Version Detection
 { :version=>/jquery(\.min)?\.js\?ver=([0-9\.]+)['"]/, :offset=>1 },
-{ :version=>/jquery\/([0-9\.]+)\/jquery(\.min)?\.js/, :offset=>0 },
 { :version=>/jquery-([0-9\.]+)(\.min)?\.js/, :offset=>0 }
 
 ]

--- a/plugins/typo3.rb
+++ b/plugins/typo3.rb
@@ -21,7 +21,7 @@ website "http://typo3.com/"
 matches [
 
 # Version Detection # Meta Generator
-{ :version=>/<meta name="generator" content="TYPO3 ([\d\.]+) CMS" \/>/ },
+{ :version=>/<meta name="generator" content="TYPO3 ([\d\.]+) CMS"( \/)?>/, :offset=>0 },
 
 # HTML Comment
 { :text=>'<!--TYPO3SEARCH_end-->', :certainty=>75 },

--- a/plugins/typo3.rb
+++ b/plugins/typo3.rb
@@ -21,7 +21,7 @@ website "http://typo3.com/"
 matches [
 
 # Version Detection # Meta Generator
-{ :version=>/<meta name="generator" content="TYPO3 ([\d\.]+) CMS"( \/)?>/, :offset=>0 },
+{ :version=>/<meta name="generator" content="TYPO3 ([\d\.]+) CMS"/ },
 
 # HTML Comment
 { :text=>'<!--TYPO3SEARCH_end-->', :certainty=>75 },


### PR DESCRIPTION
The TYPO3 Plugin does not match the version string from the MetaGenerator if the tag is not enclosed with a `\>`, but a `>` only.

This PR makes the regex forgiving, by discarding the closing tag.