### PR TITLE
feat: detect jquery when version appears in filepath

### DIFF
--- a/plugins/jquery.rb
+++ b/plugins/jquery.rb
@@ -29,6 +29,7 @@ matches [
 
 # JavaScript # Version Detection
 { :version=>/jquery(\.min)?\.js\?ver=([0-9\.]+)['"]/, :offset=>1 },
+{ :version=>/jquery\/([0-9\.]+)\/jquery(\.min)?\.js/, :offset=>0 },
 { :version=>/jquery-([0-9\.]+)(\.min)?\.js/, :offset=>0 }
 
 ]


### PR DESCRIPTION
When The JQuery Version is stored in the filepath and not in the filename, the version is currently not detected. This PR adds the corresponding regex. This will e.g. match:
`<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.min.js"></script>`