### PR TITLE
Fixed bug in Basic Auth credentials parsing

### DIFF
--- a/whatweb
+++ b/whatweb
@@ -878,8 +878,11 @@ begin
 					raise("Cookie require a parameter, e.g. name=value; name2=value2")
 				end
 			when '-u','--user'
-				$BASIC_AUTH_USER=arg.split(":").first
-				$BASIC_AUTH_PASS=arg.to_s.scan(/^[^:]*:(.+)/).to_s if arg =~ /^[^:]*:(.+)/
+				if arg.include?(':')
+					$BASIC_AUTH_USER, $BASIC_AUTH_PASS = arg.split(":", 2)
+				else
+					raise("Incorrect credentials format.")
+				end
 			when '--debug'
 				$WWDEBUG = true
 			when '--short-help'


### PR DESCRIPTION
Scan method returns an array, but the string is required