### PR TITLE
Decode HTML entities on Title plugin

### DIFF
--- a/plugins/title.rb
+++ b/plugins/title.rb
@@ -25,7 +25,7 @@ passive do
 		end
 
 		# Strip all newlines in title string (for better output)
-		m << {:name=>"page title",:string=>title.strip}
+		m << {:name=>"page title",:string=>CGI.unescapeHTML(title).strip}
 	end
 	m
 end


### PR DESCRIPTION
## Description
 This PR fixes the issue #203 where some characters are encoded in the HTML title.

## Before

![before](https://user-images.githubusercontent.com/1998649/70383678-93f54d80-1926-11ea-9d7b-be156d51462a.png)

## After

![after](https://user-images.githubusercontent.com/1998649/70383679-9c4d8880-1926-11ea-9696-025d8bbfb5ff.png)
