### PR TITLE
Fixed Mongodb logging and charset bugs

### DIFF
--- a/plugins-disabled/charset.rb
+++ b/plugins-disabled/charset.rb
@@ -25,18 +25,9 @@ Plugin.define do
 	end
 
 passive do
-	def get_charset(body)
-    charset = nil
-    meta_content_tag = body.scan(/<meta[^>]+Content-Type[^>]+>/i)[0]
-    # puts meta_content_tag
-    unless meta_content_tag.nil? or not meta_content_tag =~ /charset=['"]?([a-zA-Z0-9_-]+)/i
-      charset = meta_content_tag.scan(/charset=['"]?([a-zA-Z0-9_-]+)/i)[0][0]
-      charset.upcase!
-    end
-    charset
-  end
-  
+
   m = []
+  body=@body
 
 =begin
 			Arabic (Windows)	Windows-1256
@@ -76,9 +67,14 @@ passive do
 
 		trythese = %w| UTF_8 ASCII | # it's stack backwards
 
-		charset = get_charset(body)
+		charset = nil
+		meta_content_tag = body.scan(/<meta[^>]+Content-Type[^>]+>/i)[0]
+		# puts meta_content_tag
+		unless meta_content_tag.nil? or not meta_content_tag =~ /charset=['"]?([a-zA-Z0-9_-]+)/i
+			charset = meta_content_tag.scan(/charset=['"]?([a-zA-Z0-9_-]+)/i)[0][0]
+			charset.upcase!
+		end
 		trythese.push(charset) unless charset.nil?
-
 
 		found=false
 		while trythis = trythese.pop
@@ -87,7 +83,7 @@ passive do
 			found = true
 			m << {:string=> trythis}
 			break
-		rescue		
+		rescue
 			#
 		end
 

--- a/whatweb
+++ b/whatweb
@@ -176,7 +176,7 @@ EXAMPLE USAGE:
 
 * Scan the local network for https websites.
   whatweb --no-errors --url-prefix https:// 192.168.0.0/24
-  
+
 * Scan for crossdomain policies in the Alexa Top 1000.
   ./whatweb -i plugin-development/alexa-top-100.txt \\
   --url-suffix /crossdomain.xml -p crossdomain_xml
@@ -575,7 +575,7 @@ logging_list << LoggingVerbose.new if $verbose > 0 # full logging if -v
 ## logging dependencies
 if mongo[:use_mongo_log]
   if plugins.map { |a, _b| a }.include?('Charset')
-    logging_list << OutputMongo.new(mongo)
+    logging_list << LoggingMongo.new(mongo)
   else
     error('MongoDB logging requires the Charset plugin to be activated. The Charset plugin is the slowest whatweb plugin, it not included by default, and resides in the plugins-disabled folder. Use ./whatweb -p +./plugins-disabled/charset.rb to enable it.')
     exit
@@ -618,16 +618,16 @@ end
 # run scan
 scanner.scan do | target |
 
-  # change so we can call it without Target object and with just Headers, HTML, etc.  
+  # change so we can call it without Target object and with just Headers, HTML, etc.
   # note this modifies target with redirection info
   result = WhatWeb::Parser.run_plugins(target, plugins, scanner: scanner)
 
   # check for redirection
   WhatWeb::Redirect.new(target, scanner, max_redirects)
 
-  WhatWeb::Parser.parse(target, 
-                        result, 
-                        logging_list: logging_list, 
+  WhatWeb::Parser.parse(target,
+                        result,
+                        logging_list: logging_list,
                         grep_plugin: use_custom_grep_plugin)
 end
 


### PR DESCRIPTION
The logging to MongoDB was not working because it was still referring to the old naming of the output class.

In the charset plugin, the body was never referenced correctly, and for some reason the get_charset function was not able to be called inside the passive do-block, so I just pulled out the code and ran it directly since it was only called once anyway.

My knowledge of Ruby is very limited, but logging to MongoDB works now, as it did in version 0.4.9.
