### PR TITLE
Fix symbolic link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install:
 
 	# copy whatweb into LIBPATH/NAME/ and create a symbolic link in the BINPATH
 	install -p $(INSTALLD) -m 755 $(NAME) $(DESTDIR)$(LIBPATH)/$(NAME)
-	ln -s $(DESTDIR)$(LIBPATH)/$(NAME)/$(NAME) $(DESTDIR)$(BINPATH)/$(NAME)
+	ln -s $(LIBPATH)/$(NAME)/$(NAME) $(DESTDIR)$(BINPATH)/$(NAME)
 
 	cp -p -r my-plugins $(DESTDIR)$(LIBPATH)/$(NAME)/
 	cp -p -r plugins-disabled plugins lib plugin-development addons $(DESTDIR)$(LIBPATH)/$(NAME)/


### PR DESCRIPTION
The symbolic link should point to real directory and not to DESTDIR prefixed build directory.