### PR TITLE
ipv6-local-link-support

### DIFF
--- a/lib/target.rb
+++ b/lib/target.rb
@@ -257,16 +257,16 @@ class Target
 
   def open_url(options)
     begin
-      @ip = Resolv.getaddress(@uri.host)
+      @ip = Resolv.getaddress(@uri.hostname)
     rescue StandardError => err
       raise err
     end
 
     begin
       if $USE_PROXY == true
-        http = ExtendedHTTP::Proxy($PROXY_HOST, $PROXY_PORT, $PROXY_USER, $PROXY_PASS).new(@uri.host, @uri.port)
+        http = ExtendedHTTP::Proxy($PROXY_HOST, $PROXY_PORT, $PROXY_USER, $PROXY_PASS).new(@uri.hostname, @uri.port)
       else
-        http = ExtendedHTTP.new(@uri.host, @uri.port)
+        http = ExtendedHTTP.new(@uri.hostname, @uri.port)
       end
 
       # set timeouts


### PR DESCRIPTION
whatweb don't support ipv6 local link，e.g. 'http://[11::10:220]'  or ''http://[11::10:220]:8080'。

for example
uri = URI("http://[11::10:220]")
uri.hostname   #11::10:220
uri.host            #[11::10:220]

when use Net::HTTP.start(host,port), uri.host can't connect，but uri.hostname is ok。



'