### PR TITLE
change mongo logging policy to upsert (update by default, insert if new)

### DIFF
--- a/lib/logging/mongodb.rb
+++ b/lib/logging/mongodb.rb
@@ -92,7 +92,7 @@ class LoggingMongo < Logging
     else
       Helper::utf8_elements!(foo) # convert foo to utf-8
       flatten_elements!(foo)
-      @coll.insert_one(foo)
+      @coll.replace_one({ target: foo[:target]}, foo, { upsert: true})
     end
   end
 end


### PR DESCRIPTION
This PR replaces insert_one() by replace_one() with upsert policy in mongo logging. With upsert, the document in mongo will be replaced if target already exists and inserted if the document doesn't exist. I think that it is more convenient than inserting when the only thing that you want to know is the latest version number of a middleware. I also realize that insert_one() would be better when you want to maintain a history of all the version updates (even repeating all the data about the target just changing the version number of a single attribute...)

Ideally, we should have an option to switch between insert or replace.