### PR TITLE
Replace username by user in Mongo Client connection options

### DIFF
--- a/lib/logging/mongodb.rb
+++ b/lib/logging/mongodb.rb
@@ -8,7 +8,7 @@ class LoggingMongo < Logging
 
     options = { database: database }
     if s[:username]
-      options[:username] = s[:username]
+      options[:user] = s[:username]
       options[:password] = s[:password]
     end
 


### PR DESCRIPTION
According to the API docs for Mongo Client connection options:
https://api.mongodb.com/ruby/current/Mongo/Client.html#initialize-instance_method:~:text=characters-,.,%3A
the correct value for specifying the username of the connection string is **user**, not **username**.

Trying to log to mongo using "username" instead of "user" will yield the following error:

`ERROR Logging failed: https://domain.com - there are no users authenticated (13) (on localhost, legacy retry, attempt 1)`

It is also more clearly highlighted when using --debug option in whatweb:

`W, [2020-11-25T22:02:15.304776 #262609]  WARN -- : MONGODB | Unsupported client option 'username'. It will be ignored.`

The attached patch allows to connect using authentication options and insert logs into mongo without problems:

` ./whatweb -p +./plugins-disabled/charset.rb  --log-mongo-host localhost --log-mongo-database whatwebdb --log-mongo-username yyyyyyy --log-mongo-password xxxxxxx   https://domain.com`

