### PR TITLE
Fix escape_for_sql method

### DIFF
--- a/lib/logging/sql.rb
+++ b/lib/logging/sql.rb
@@ -45,11 +45,7 @@ class LoggingSQL < Logging
 
   def escape_for_sql(s)
     s = s.to_s
-    if s.nil?
-      "''"
-    else
-      "'" + s.tr("'", "\'") + "'"
-    end
+    "'" + s.gsub("'"){"\\'"} + "'"
   end
 
   def create_tables


### PR DESCRIPTION
The previous version was quite broken:
https://github.com/urbanadventurer/WhatWeb/blob/3e7d5eeedcf678b5624955122097330f43563360/lib/logging/sql.rb#L46-L53

Specifically, [this line](https://github.com/urbanadventurer/WhatWeb/blob/3e7d5eeedcf678b5624955122097330f43563360/lib/logging/sql.rb#L51) is not doing what we suppose it'll do:

` "'" + s.tr("'", "\'") + "'"`

Apparently, it seems that a string like `escape'me` would be translated to `escape\'me` but that's not the case:

```
2.7.2 :055 > "escape'me".tr("'","\'")
 => "escape'me"
```

You can find a good explanation of why [here](https://stackoverflow.com/a/12701027/243532). 

So the `escape_for_sql` method wasn't really escaping anything o_O 

Finally, I think that this `if` branch is unneded: https://github.com/urbanadventurer/WhatWeb/blob/3e7d5eeedcf678b5624955122097330f43563360/lib/logging/sql.rb#L48-L50
In fact, `nil.to_s` surprisingly works (it would be a clear npe exception in Java!) and casts nil to an empty string "", making the whole `if` block superfluous. 

```
2.7.2 :046 > b=nil
 => nil
2.7.2 :047 > b.nil?
 => true
2.7.2 :049 > b.to_s
 => ""
2.7.2 :050 > b.to_s.nil?
 => false
```