### PR TITLE
Fix #311 - JSON Logging fails... UTF-8 can't modify frozen String

### DIFF
--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -38,7 +38,11 @@ module Helper
   # converts a string to UTF-8
   def self.convert_to_utf8(str)
     if defined?(String.new.scrub) # Defined in Ruby 2.1
-      str.force_encoding("UTF-8").scrub
+      if (str.frozen?)
+	str.dup.force_encoding("UTF-8").scrub
+      else
+        str.force_encoding("UTF-8").scrub
+      end
     else # Ruby 2.0
       str.encode('UTF-16', 'UTF-8', invalid: :replace, replace: '').encode('UTF-8')
     end


### PR DESCRIPTION
The problem is in `lib/helper.rb`, `convert_to_utf8` method. It tries to change a frozen String. Probably because whatweb detects a multi-version CMS (e.g., Wordpress 4.x and 4.y.)

https://github.com/urbanadventurer/WhatWeb/blob/1b3516975571c3f59d686f82a6d2dbf6f1011029/lib/helper.rb#L38-L47


Tracing the origin of this bug I think that the main reason is the following:

https://github.com/urbanadventurer/WhatWeb/blob/1b3516975571c3f59d686f82a6d2dbf6f1011029/lib/plugins.rb#L58-L59

Plugins's names are frozen, so trying to encode them twice (or more) to UTF-8 (due to multiple-version detection) will yield the error.

With this PR I propose a simple workaround in `lib/helper.rb`.

I don't have a Ruby 2.0 version available here to test that branch of the if conditional. In fact, I'd suggest to remove that branch and ask for at least Ruby 2.1 (available since 2013!)

What do you think?

