### PR TITLE
Add regex for generic jquery detection in primefaces web applications

### DIFF
--- a/plugins/jquery.rb
+++ b/plugins/jquery.rb
@@ -26,7 +26,8 @@ matches [
 # JavaScript # Version Detection
 { :version=>/jquery(\.min)?\.js\?ver=([0-9\.]+)['"]/, :offset=>1 },
 { :version=>/jquery\/([0-9\.]+)\/jquery(\.min)?\.js/, :offset=>0 },
-{ :version=>/jquery-([0-9\.]+)(\.min)?\.js/, :offset=>0 }
+{ :version=>/jquery-([0-9\.]+)(\.min)?\.js/, :offset=>0 },
+{ :version=>/jquery(\.min)?\.js(\.[a-z&=;\?]*)(\?|;)(v|ver)=([0-9\.]+)['"]/, :offset=>4 },
 
 ]
 


### PR DESCRIPTION
Hi,
I am currently testing a web application which is using the Java UI framework Primefaces. In Primefaces the import of JQuery does look a little bit different. Currently Whatweb is not able to detect the version. 

I have created a new regular expression for the JQuery version detection in Primefaces. The import looks like the following:

`src="/javax.faces.resource/jquery/jquery.js.xhtml?ln=primefaces&amp;v=6.2.12"`

The new regex is written in a way that is able to detect the JQuery version not only in Primefaces but also in other possible formats.

Let me know what you think about the new regex.

Best regards

Manuel