### PR TITLE
add bundler setup requirement

### DIFF
--- a/whatweb
+++ b/whatweb
@@ -34,6 +34,7 @@
 
 $LOAD_PATH.unshift(File.join(File.expand_path(__dir__)), '.')
 
+require 'bundler/setup'
 require 'lib/whatweb'
 
 #


### PR DESCRIPTION
this is needed to make whatweb work after following the installation instructions.

The current installation instructions for manual install tel me to

git clone repo
cd WhatWeb
bundle install
-> Your user account isn't allowed to install to the system RubyGems.
  You can cancel this installation and run:

      bundle config set --local path 'vendor/bundle'
      bundle install


So I run
bundle config set --local path 'vendor/bundle'
bundle install
 -> Bundle complete! 11 Gemfile dependencies, 28 gems now installed.
Bundled gems are installed into `./vendor/bundle`

./whatweb    
WhatWeb is not installed and is missing dependencies.
The following gems are missing:
 - addressable

To install run the following command from the WhatWeb folder:
'bundle install'



running `bundle exec whatweb` does work
`ruby -rbundler/setup whatweb ` also works

And so this patch also works.