### PR TITLE
add missing dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,12 @@ gem 'addressable'
 # JSON logging
 gem 'json'
 
+# CLI argument parsing
+gem 'getoptlong', '~> 0.1'
+
+# asynchronous DNS
+gem 'resolv-replace', '~> 0.1'
+
 # MongoDB logging - optional
 # To use: bundle install --with mongo
 group :mongo, optional: true do


### PR DESCRIPTION
https://github.com/urbanadventurer/WhatWeb/blob/36fd28b83e03a4eb3ac6db27830595abababcf32/lib/whatweb.rb#L22 

getoptlong is no longer part of native gems in Ruby 3.4, so it need to be included in Gemfile

https://github.com/urbanadventurer/WhatWeb/blob/36fd28b83e03a4eb3ac6db27830595abababcf32/CHANGELOG.md?plain=1#L372

Them changelog tells "em-resolv-replace" was removed, but the code still requires resolv-replac which is a third party lib

https://github.com/urbanadventurer/WhatWeb/blob/36fd28b83e03a4eb3ac6db27830595abababcf32/lib/whatweb.rb#L29