### PR TITLE
Fixed Hikivision detection for newer models

### DIFF
--- a/plugins/hikvision.rb
+++ b/plugins/hikvision.rb
@@ -8,15 +8,14 @@ Plugin.define do
 name "HikVision"
 authors [
   "Brendan Coles <bcoles@gmail.com>", # 2011-07-15
+  "John de Kroon <john.de.kroon@cyberant.com" # 2025-10-15 added passive detection for newer versions
 ]
-version "0.1"
+version "0.2"
 description "HikVision cameras, Digital Video Servers (DVS) and Digital Video Records (DVR)"
-website "http://www.hikvisionusa.com/"
+website "http://www.hikvision.com/"
 
 # ShodanHQ results as at 2011-07-15 #
 # 58,133 for Hikvision-Webs
-
-
 
 # Matches #
 matches [
@@ -25,6 +24,23 @@ matches [
 { :search=>"headers[server]", :regexp=>/^Hikvision-Webs$/ },
 
 ]
+
+# Passive detection #
+# In newer versions the server header is changed to just "Webs", which is too little to assume that it's HikVision.
+# Therefore we also test for the redirect to the login page. The combination should be reliable.
+passive do
+    m=[]
+    # Header check (case‑insensitive key lookup)
+    server_header = @headers['server'] || @headers['Server']
+    header_match  = server_header&.include?('Webs')
+
+    # Body check – look for the exact JS string
+    body_match = @body.include?('window.location.href = "./doc/page/login.asp?_"')
+
+    m << { :certainty=>100 } if header_match && body_match
+
+    m
+end
 
 end
 


### PR DESCRIPTION
In newer versions, the server header is changed to just "Webs" instead of "Hikvision-Webs", which is too little to assume that it's HikVision. Therefore I added a passive test that looks for a combination of the Webs header and a specific redirect to the login page. The combination should be reliable.