### PR TITLE
Fix make install on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 NAME = whatweb
-PREFIX ?= /usr
 BINPATH = $(PREFIX)/bin
 LIBPATH = $(PREFIX)/share
 MANPATH = $(PREFIX)/share/man
@@ -14,6 +13,7 @@ INSTALLD =
 PREFIX ?= /usr/local
 else
 INSTALLD = -D
+PREFIX ?= /usr
 endif
 
 install:


### PR DESCRIPTION
WhatWeb cannot be installed to `/usr` on macOS. The automatic switch to `/usr/local` fails as `PREFIX` is already set on line 2.