### PR TITLE
Fix bundler gem detection when using vendor/bundle

### DIFF
--- a/whatweb
+++ b/whatweb
@@ -11,6 +11,13 @@
 #
 #
 # WhatWeb - Next generation web scanner.
+#
+# Set up Bundler to find gems in vendor/bundle if available
+gemfile_path = File.join(File.expand_path(__dir__), 'Gemfile')
+if File.exist?(gemfile_path)
+  ENV['BUNDLE_GEMFILE'] ||= gemfile_path
+  require 'bundler/setup'
+end
 # Developed by Andrew Horton (urbanadventurer) and Brendan Coles (bcoles)
 #
 # Homepage: https://morningstarsecurity.com/research/whatweb


### PR DESCRIPTION
## Summary
- Add `bundler/setup` at script start so gems installed via `bundle install` to `vendor/bundle` are properly detected
- Eliminates the need to run `bundle exec ./whatweb` after installing dependencies

## Problem
After running `bundle install`, WhatWeb would still report missing gems because `Gem::Specification.find_by_name()` only looks for system-wide gems, not those in `vendor/bundle`.

## Test plan
- [x] Run `bundle install` to install gems to `vendor/bundle`
- [x] Run `./whatweb -h` - should display help without "missing gems" error
- [x] Run `./whatweb --version` - should display version info

🤖 Generated with [Claude Code](https://claude.com/claude-code)