### PR TITLE
Add client certificate (mTLS) authentication support via --client-cert/--client-key

### DIFF
--- a/lib/extend-http.rb
+++ b/lib/extend-http.rb
@@ -177,6 +177,16 @@ class ExtendedHTTP < Net::HTTP #:nodoc:
       @ssl_context = OpenSSL::SSL::SSLContext.new
       @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
       
+      if defined?($CLIENT_CERT_FILE) && $CLIENT_CERT_FILE
+        begin
+          @ssl_context.cert = OpenSSL::X509::Certificate.new(File.read($CLIENT_CERT_FILE))
+          @ssl_context.key  = OpenSSL::PKey.read(File.read($CLIENT_KEY_FILE), $CLIENT_KEY_PASS)
+        rescue StandardError => e
+          warn "ERROR loading client certificate/key: #{e.message}"
+          exit 1
+        end
+      end
+
       # Configure SSL context for maximum compatibility with ALL protocols
       begin
         if @ssl_context.respond_to?(:ssl_version=)

--- a/lib/extend-http.rb
+++ b/lib/extend-http.rb
@@ -110,6 +110,15 @@ class ExtendedHTTP < Net::HTTP #:nodoc:
       # Now establish SSL over the tunneled connection
       @ssl_context = OpenSSL::SSL::SSLContext.new
       @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      if defined?($CLIENT_CERT_FILE) && $CLIENT_CERT_FILE
+        begin
+          @ssl_context.cert = OpenSSL::X509::Certificate.new(File.read($CLIENT_CERT_FILE))
+          @ssl_context.key  = OpenSSL::PKey.read(File.read($CLIENT_KEY_FILE), $CLIENT_KEY_PASS)
+        rescue StandardError => e
+          warn "ERROR loading client certificate/key: #{e.message}"
+          exit 1
+        end
+      end
       
       # Configure SSL context for maximum compatibility with ALL protocols
       begin

--- a/whatweb
+++ b/whatweb
@@ -182,6 +182,12 @@ PERFORMANCE & STABILITY:
   --output-buffer-size=SIZE\tSet output buffer size. 0=unbuffered,
 \t\t\t\tdefault=auto based on thread count.
 
+CLIENT AUTHENTICATION:
+  --client-cert=FILE\t\tClient SSL certificate (PEM format) for
+\t\t\t\tmutual TLS authentication.
+  --client-key=FILE\t\tClient SSL private key (PEM format).
+  --client-key-pass=PASS\tPassphrase for the client key, if encrypted.
+
 HELP & MISCELLANEOUS:
   --short-help\t\t\tShort usage help.
   --help, -h\t\t\tComplete usage help.
@@ -380,6 +386,9 @@ opts = GetoptLong.new(
   ['-g', '--grep', GetoptLong::REQUIRED_ARGUMENT],
   ['--open-timeout', GetoptLong::REQUIRED_ARGUMENT],
   ['--read-timeout', GetoptLong::REQUIRED_ARGUMENT],
+  ['--client-cert', GetoptLong::REQUIRED_ARGUMENT],
+  ['--client-key', GetoptLong::REQUIRED_ARGUMENT],
+  ['--client-key-pass', GetoptLong::REQUIRED_ARGUMENT],
   ['--header', '-H', GetoptLong::REQUIRED_ARGUMENT],
   ['--cookie', '-c', GetoptLong::REQUIRED_ARGUMENT],
   ['--cookie-jar', GetoptLong::REQUIRED_ARGUMENT],
@@ -534,6 +543,16 @@ begin
       $HTTP_OPEN_TIMEOUT = arg.to_i
     when '--read-timeout'
       $HTTP_READ_TIMEOUT = arg.to_i
+    when '--client-cert'
+      raise("Client certificate file not found: #{arg}") unless File.readable?(arg)
+
+      $CLIENT_CERT_FILE = arg
+    when '--client-key'
+      raise("Client key file not found: #{arg}") unless File.readable?(arg)
+      
+      $CLIENT_KEY_FILE = arg
+    when '--client-key-pass'
+      $CLIENT_KEY_PASS = arg
     when '--wait'
       $WAIT = arg.to_i
     when '-H', '--header'


### PR DESCRIPTION
## Problem

WhatWeb has no way to authenticate against targets protected by mutual TLS (client certificate authentication). This came up during an external gray-box pentest engagement, where the customer's host required a client certificate for any TLS connection — without it, WhatWeb fails immediately with:

> SSL_read: tlsv13 alert certificate required

Two workarounds were tried first and did not work:

- **Routing through an intercepting proxy (Burp)** configured with the client certificate. This doesn't work because WhatWeb's proxy handling only tunnels a plain `CONNECT` request to the proxy — it has no mechanism to delegate TLS client authentication to the proxy for its own requests.
- **Installing the certificate in the OS certificate store** (Windows Certificate Store) and running WhatWeb natively. This doesn't work either, because Ruby's OpenSSL bindings have no integration with OS certificate stores at all — `OpenSSL::X509::Certificate` and `OpenSSL::PKey` only load certificates/keys from PEM/DER files via explicit file reads. No amount of OS-level installation makes a cert visible to Ruby.

Extracting the certificate and key from the original `.pfx` file into standalone `.crt`/`.key` files and loading them directly was the only reliable path — which is what this PR implements support for.

## Solution

Added three new CLI options:

- `--client-cert=FILE` — client certificate (PEM format)
- `--client-key=FILE` — client private key (PEM format)
- `--client-key-pass=PASSWORD` — passphrase for the key, if encrypted

The certificate and key are loaded into the SSL context used by WhatWeb's internal `ExtendedHTTP` class (`lib/extend-http.rb`), in
**both** places a TLS context is created: the direct-SSL connection branch and the HTTPS-through-proxy (`CONNECT`) branch, so it works whether or not `--proxy` is used.

File paths are validated at option-parsing time (fail fast, clear error message). Certificate/key parsing errors are raised per request rather than killing the whole process, consistent with how WhatWeb handles other per-target errors.

`verify_mode` remains `OpenSSL::SSL::VERIFY_NONE`, unchanged from existing behavior — this PR only adds client-side certificate
presentation, it does not add server certificate validation.

## Usage

    ./whatweb --client-cert=/path/client.crt --client-key=/path/client.key https://target.example
    ./whatweb --client-cert=/path/client.crt --client-key=/path/client.key --client-key-pass='secret' https://target.example

Certificates originally issued as a single `.pfx` file can be split into separate `.crt`/`.key` files (e.g. via `openssl pkcs12`) before use.

## Testing

Verified against a real client host during a pentest engagement:

- Without `--client-cert`: connection fails with `SSL_read: tlsv13 alert certificate required`
- With `--client-cert`/`--client-key`: TLS handshake succeeds and the scan completes normally
- Confirmed default behavior (no flags passed) is unaffected — existing scans work exactly as before